### PR TITLE
remove votes from priority fee estimates by default

### DIFF
--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -310,7 +310,7 @@ impl AtlasPriorityFeeEstimator {
 // default to true for backwards compatibility. Recommended fee does not include vote txns
 fn should_include_vote(options: &Option<GetPriorityFeeEstimateOptions>) -> bool {
     if let Some(options) = options {
-        return options.include_vote.unwrap_or(true) || !options.recommended.unwrap_or(false);
+        return options.include_vote.unwrap_or(false);
     }
     true
 }


### PR DESCRIPTION
Votes are processed in a different thread (2x for votes, 4x for reg txns). We don't care about them for priority estimates.

Tested locally.