### PR TITLE
RPC-456 changing priority fee recommendation by removing the .5% increase of every request

### DIFF
--- a/src/rpc_server.rs
+++ b/src/rpc_server.rs
@@ -498,17 +498,13 @@ fn should_include_vote(options: &Option<GetPriorityFeeEstimateOptions>) -> bool 
 
 const MIN_RECOMMENDED_PRIORITY_FEE: f64 = 10_000.0;
 
-// Safety buffer on the recommended fee to cover cases where the priority fee is increasing over each block.
-const RECOMMENDED_FEE_SAFETY_BUFFER: f64 = 0.05;
-
 pub fn get_recommended_fee(priority_fee_levels: MicroLamportPriorityFeeEstimates) -> f64 {
     let recommended = if priority_fee_levels.medium > MIN_RECOMMENDED_PRIORITY_FEE {
         priority_fee_levels.medium
     } else {
         MIN_RECOMMENDED_PRIORITY_FEE
     };
-    let recommended_with_buffer = recommended * (1.0 + RECOMMENDED_FEE_SAFETY_BUFFER);
-    recommended_with_buffer.ceil()
+    recommended.ceil()
 }
 
 #[cfg(test)]
@@ -635,7 +631,7 @@ mod tests {
         });
         let resp = result.unwrap();
         assert!(resp.priority_fee_levels.is_none());
-        assert_eq!(resp.priority_fee_estimate, Some(10500.0));
+        assert_eq!(resp.priority_fee_estimate, Some(10000.0));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

-   The code used to add a 5% increase to recommended fee, however, in slow cycles or in single user accounts it causes an artificial linear fee growth which is not desirable. Removing the fee bump.
- 
## Testing

-   Testing performed to validate the changes
