### PR TITLE
Fix README for priority fee details

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ reused during analysis and during dev / operational stages
 {
   "id": "version1",
   "jsonrpc": "2.0",
-  "method": "getPriorityFeeEstimateDetails",
+  "method": "getPriorityFeeEstimate",
   "params": [
     {
       "accountKeys": [
 "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
       ],
-      "options": {"recommended": true}
+      "options": {"recommended": true, "includeDetails":  true}
     }
   ]
 }


### PR DESCRIPTION
Method `getPriorityFeeEstimateDetails` does not exist

Update docs to reflect that the expected result can be obtained with method `getPriorityFeeEstimate` and by passing `{"includeDetails": true}` in options
